### PR TITLE
-   **Modbus TCP Communication (`robot_comm.py`, `main.py`)**:

### DIFF
--- a/app_data/modbus_config.json
+++ b/app_data/modbus_config.json
@@ -1,9 +1,10 @@
 {
-    "host": "127.0.0.1",
+    "host": "192.168.56.1",
     "port": "502",
+    "modbus_offset": "32768",
     "req_addr": "100",
-    "is_coil": true,
+    "is_coil": false,
     "max_objs": "5",
-    "num_obj_addr": "200",
-    "data_start_addr": "201"
+    "num_obj_addr": "0",
+    "data_start_addr": "1"
 }

--- a/src/variables.py
+++ b/src/variables.py
@@ -98,13 +98,14 @@ MODBUS_TCP_PORT = 502            # Default Modbus TCP Port
 MODBUS_TIMEOUT = 5               # Connection timeout in seconds
 
 # --- Additions for PLC Data Request ---
+MODBUS_DEFAULT_OFFSET_BASE = 32768
 MODBUS_DATA_REQUEST_ADDR = 100   # <== CHANGE THIS: Address of the PLC register/coil for requesting data
 MODBUS_IS_REQUEST_FLAG_COIL = False # <== CHANGE THIS: True if the request flag is a Coil, False if a Holding Register
-
+MODBUS_DATA_REQUEST_ADDR_IDX = 100 # <== CHANGE THIS: Address for the register/coil holding the request flag
 # --- Additions for Multi-Object Packets ---
 MODBUS_MAX_OBJECTS = 5              # <== CHANGE THIS: Max objects per packet PLC can handle
-MODBUS_NUM_OBJECTS_ADDR = 200       # <== CHANGE THIS: Address for register holding the number of objects
-MODBUS_OBJECT_DATA_START_ADDR = 201 # <== CHANGE THIS: Start address for the data of the first object
+MODBUS_NUM_OBJECTS_ADDR_IDX = 0       # <== CHANGE THIS: Address for register holding the number of objects
+MODBUS_OBJECT_DATA_START_ADDR_IDX = 1 # <== CHANGE THIS: Start address for the data of the first object
 MODBUS_REGISTERS_PER_OBJECT = 7     # Number of registers used per object (id, x, y, w, h, angle, category) - Usually stays 7 based on your old send_data
 
 


### PR DESCRIPTION
    -   Refined `RobotComm` class for establishing and managing Modbus TCP connections.
    -   Implemented methods for reading/writing flags and sending structured object data to a TwinCAT PLC.
    -   Added a "Modbus TCP" tab in the GUI (`main.py`) for:
        -   Manual IP/Port configuration.
        -   Configuration of PLC data structure addresses (request flag, data start, etc.).
        -   Saving and loading Modbus connection settings to/from `modbus_config.json`.
        -   Displaying connection status.
    -   Integrated logic to use an address offset (e.g., `32768`) for Modbus registers, allowing users to input PLC array indices in the GUI, with real-time display of effective Modbus addresses.

-   **Working Mode Modbus Integration (`main.py`)**:
    -   Enabled optional Modbus communication in "Working Mode" via a checkbox.
    -   The working mode thread now:
        -   Reads a request flag from the PLC using the configured Modbus address.
        -   Prepares and sends a packet of detected object data (ID, coordinates, dimensions, angle, category code) to the PLC if the flag is set.
        -   Resets the PLC request flag after data transmission.

-   **GUI for Modbus Configuration (`main.py`)**:
    -   Added input fields for IP, Port, Modbus Address Offset, Request Flag Address/Index, Flag Type (Coil/Register), Max Objects per Packet, and Packet Start Address/Index.
    -   Implemented dynamic display of "Effective Modbus Address" next to address/index input fields, calculated based on the entered index and offset.

-   **Modbus Connection (`robot_comm.py`, `main.py`)**:
    -   **Fixed `socket.gaierror: [Errno 11001] getaddrinfo failed`**: Ensured the Python client uses a correctly formatted IPv4 address for connection attempts, resolving issues caused by invalid IP strings.
    -   **Fixed `TypeError: 'bool' object is not callable` for `ModbusClient.is_open`**: Corrected the usage of the `is_open` attribute in `pyModbusTCP.client.ModbusClient` by accessing it as a property (`client.is_open`) instead of calling it as a method (`client.is_open()`).
    -   **Fixed `TypeError: 'str' object is not callable` for `ModbusClient.last_error_as_txt`**: Corrected the usage of `last_error_as_txt` by accessing it as a property.
    -   Improved connection logic in `RobotComm.connect()` for clarity and explicit control (using `auto_open=False`).

-   **TwinCAT Modbus Server (TS6250) Integration**:
    -   **Fixed Modbus Exception Code 2 ("Illegal Data Address")**:
        -   Ensured Python client requests appropriate Modbus addresses by implementing an offset system (e.g., `32768` for default TS6250 mapping of `mb_Output_Registers`).
        -   Clarified that client should request Holding Registers for flag/data when PLC variables are `WORD` arrays.
    -   **Fixed Modbus Exception Code 4 ("Slave Device Failure") / TwinCAT Error "CAdsWatchServerR0::AdsSearchSymbol(...) symbol not found!"**:
        -   Resolved symbol naming mismatch between the PLC GVL name (e.g., `GVL_ModBus`) and the name expected by TS6250 in `TcModbusSrv.xml` (e.g., `GVL`).
        -   **Solution Applied:** Renamed PLC GVL to `GVL` and updated PLC code references to match the default TS6250 XML expectation for `<VarName>.GVL.mb_Output_Registers</VarName>`. (Alternative: Modify XML to use `.GVL_ModBus.mb_Output_Registers`).
        -   Ensured the GVL `GVL_ModBus` (now `GVL`) in TwinCAT did not have `qualified_only` if relying on the default XML mapping looking for just `.mb_Output_Registers`, or that `qualified_only` was used consistently with the full path in a custom XML. The final working solution involved renaming to `GVL` and likely having `qualified_only` or relying on global symbol resolution.

-   **TwinCAT Real-Time Execution**:
    -   **Resolved `ERR 0x1024` (TwinCAT Run Mode in Hyper-V/VBS not possible)**: Provided guidance to disable conflicting Windows features like Hyper-V, Virtualization-based Security (VBS), and Memory Integrity (HVCI) to allow TwinCAT to enter Run Mode.

-   **GUI Logic (`main.py`)**:
    -   **Fixed `RuntimeError: wrapped C/C++ object of type QLineEdit has been deleted`**: Resolved issue by ensuring QLineEdit widgets for Modbus configuration were correctly added to their parent layouts in `create_modbus_tab`, preventing premature garbage collection before their signals/slots were fully utilized during `load_modbus_settings`. Addressed duplicate widget definitions.

-   **Error Handling & Logging**:
    -   Improved error messages and logging for Modbus connection attempts and operations in both Python client and TwinCAT.
    -   Added more specific debug logs to trace Modbus packet exchange and symbol resolution issues.

-   **Modbus Parameter Handling (`main.py`)**:
    -   Refactored `start_working_mode` to correctly parse "raw" PLC indices and the "Modbus Address Offset" from GUI fields, calculate effective Modbus addresses, and pass these to the `RobotComm` instance/worker thread.
    -   Updated `variables.py` to use default "short" indices (e.g., `MODBUS_DATA_REQUEST_ADDR_IDX`) and a base offset constant (`MODBUS_DEFAULT_OFFSET_BASE`).
-   **Clarity in `robot_comm.py`**:
    -   Made `auto_open=False` the default for `ModbusClient` for more explicit connection management.# Please enter the commit message for your changes. Lines starting